### PR TITLE
２人制に変更　NULL問題の解決

### DIFF
--- a/UNOgame/src/GameSet/GameServer.java
+++ b/UNOgame/src/GameSet/GameServer.java
@@ -9,22 +9,22 @@ import java.net.ServerSocket;
 public class GameServer
 {
 	
-	private ServerSocket[] svSock = new ServerSocket[4]; //テスト用に2実際は4
-    private Socket[] sock = new Socket[4]; //上と同じ
+	private ServerSocket[] svSock = new ServerSocket[2]; //テスト用に2実際は4
+    private Socket[] sock = new Socket[2]; //上と同じ
 	
 
-	public int playerSet(int a, int b, int c ,int d)
+	public int playerSet(int a, int b)
 	{
 		try
 		{   
 			svSock[0] = new ServerSocket(a);
 		    svSock[1] = new ServerSocket(b);
-		    svSock[2] = new ServerSocket(c);
-		    svSock[3] = new ServerSocket(d);
+		    //svSock[2] = new ServerSocket(c);
+		    //svSock[3] = new ServerSocket(d);
 		    sock[0] = svSock[0].accept();
 		    sock[1] = svSock[1].accept();
-		    sock[2] = svSock[2].accept();
-		    sock[3] = svSock[3].accept();
+		    //sock[2] = svSock[2].accept();
+		    //sock[3] = svSock[3].accept();
 		}catch(IOException e)
 		{
 			e.printStackTrace();
@@ -38,7 +38,7 @@ public class GameServer
 	{
 		try
 		{
-		    for(int i = 0;i < 4;i++)//テスト用に2
+		    for(int i = 0;i < 2;i++)//テスト用に2
 		    {
 			    svSock[i].close();
 		    }

--- a/UNOgame/src/UNOset/player/Monte.java
+++ b/UNOgame/src/UNOset/player/Monte.java
@@ -13,7 +13,7 @@ public class Monte
 	public static void main(String[] args) 
 	{
 		//int num = Integer.parseInt(args[0]);
-		int num = 555;
+		int num = 666;
 	    GamePlayer player = new GamePlayer();
 	    if(0 == player.playerSet(num))
 	    {
@@ -25,10 +25,10 @@ public class Monte
 		PrintWriter write = player.getWriter();
 		
 		int roundNum = 3;
-		int playerNum = 4;
+		int playerNum = 2;
 		int pnum = 0;
 		int roundcount = 0;
-		int[] hdata = new int[4];
+		int[] hdata = new int[2];
 		int base;
 		CardList list = new CardList();
 		Card card;
@@ -140,12 +140,12 @@ public class Monte
 										   }
 									   }
 								   }
-								   server.write(card.getCardName());
+								   server.write(out.getCardName());
 								   server.read();
 								   hand.crean();
-								   hand.disCard(card.getCardName());
+								   hand.disCard(out.getCardName());
 								   
-								   if(card instanceof WildCard)
+								   if(out instanceof WildCard)
 								   {
 									   server.read();
 									   while(true)
@@ -166,7 +166,7 @@ public class Monte
 										   str = server.read();
 										   if(str.matches(".*OK.*"))
 										   {
-											   ((WildCard) card).changeColor(color);
+											   ((WildCard) out).changeColor(color);
 											   break;
 										   }
 									   }
@@ -174,7 +174,7 @@ public class Monte
 								   {
 									   server.read();
 								   }
-								   discard.discard(card);
+								   discard.discard(out);
 							   }
 							   else //ドロー系を重ねない
 							   {
@@ -212,7 +212,7 @@ public class Monte
 							   else
 							   {
 								   server.write("hand");
-								   for(int i = 0;i < 4;i++)
+								   for(int i = 0;i < 2;i++) //実験用
 								   {
 									   str = server.read();
 									   hdata[i] = Integer.parseInt(str);
@@ -241,7 +241,7 @@ public class Monte
 								   System.out.println(card.getCardName() + "d");
 								   dd++;
 							   }
-							   if(/*discard.isDiscard(card)*/true)
+							   if(true)
 							   {
 								   col = card.getCardColor();
 								   if(card instanceof WildCard)
@@ -250,6 +250,7 @@ public class Monte
 								   }
 								   str = card.getCardName();
 								   server.write(str);
+								   
 								   break;
 							   }
 							   /*else

--- a/UNOgame/src/UNOset/player/RandomPlayer.java
+++ b/UNOgame/src/UNOset/player/RandomPlayer.java
@@ -11,8 +11,8 @@ public class RandomPlayer {
 
 	public static void main(String[] args)
 	{
-		int num = Integer.parseInt(args[0]);
-		
+		//int num = Integer.parseInt(args[0]);
+		int num = 555;
 	    GamePlayer player = new GamePlayer();
 	    if(0 == player.playerSet(num))
 	    {
@@ -24,7 +24,7 @@ public class RandomPlayer {
 		PrintWriter write = player.getWriter();
 		
 		int roundNum = 3;
-		int playerNum = 4;
+		int playerNum = 2;
 		int pnum = 0;
 		int roundcount = 0;
 		CardList list = new CardList();

--- a/UNOgame/src/UNOset/player/tactics/Montecorlo.java
+++ b/UNOgame/src/UNOset/player/tactics/Montecorlo.java
@@ -40,7 +40,7 @@ public class Montecorlo
 	
 	public void makeHand(int[] data) //相手手札数から手札を作成
 	{
-		for(int i = 0;i < 4;i++)
+		for(int i = 0;i < 2;i++)
 		{
 			handNum[i] = data[i];
 		}
@@ -51,7 +51,6 @@ public class Montecorlo
 	{
 		int a = best.score[num-1];
 		int b = cor.score[num-1];
-		b = b / count;
 		if(a < b)
 		{
 			return true;
@@ -64,7 +63,7 @@ public class Montecorlo
 
 	public Card cal() //可能手を作成　run()でシュミ
 	{
-		int count = 300;
+		int count = 400;
 		String[] co = {"b","g","y","r"};
 		Card bestcard  = null;
 		RoundData best = new RoundData();
@@ -92,15 +91,15 @@ public class Montecorlo
 						((WildCard) card).changeColor(co[j]);
 						System.out.println(card.getCardName());
 						RoundData tdata = new RoundData();
-						tdata.score = new int[4];
+						tdata.score = new int[2];
 						for(int k = 0;k < count;k++)
 						{
 							//System.out.println(j);
 							temp = run(card);
 							tdata.score[0] += temp.score[0];
 							tdata.score[1] += temp.score[1];
-							tdata.score[2] += temp.score[2];
-							tdata.score[3] += temp.score[3];
+							//tdata.score[2] += temp.score[2];
+							//tdata.score[3] += temp.score[3];
 							//System.out.println("nnnn");
 						}
 						if(eval(best,tdata,count) || bestcard == null)
@@ -114,15 +113,15 @@ public class Montecorlo
 				{
 					RoundData tdata = new RoundData();
 					System.out.println(card.getCardName() + "d");
-					tdata.score = new int[4];
+					tdata.score = new int[2];
 					for(int j = 0;j < count;j++)
 					{
 						//System.out.println(j);
 						temp = run(card);
 						tdata.score[0] += temp.score[0];
 						tdata.score[1] += temp.score[1];
-						tdata.score[2] += temp.score[2];
-						tdata.score[3] += temp.score[3];
+						//tdata.score[2] += temp.score[2];
+						//tdata.score[3] += temp.score[3];
 						//System.out.println("nnnn");
 					}
 					if(eval(best,tdata,count) || bestcard == null)
@@ -185,7 +184,7 @@ public class Montecorlo
 		DisCard tdis = new DisCard();
 		String str = this.topcard.getCardName();
 		tdis.discard(list.makeCard(str));
-		Hand[] thand = new Hand[4];
+		Hand[] thand = new Hand[2];
 		Random rand = new Random();
 		for(int i = 0;i < playerNum;i++)
 		{
@@ -254,30 +253,31 @@ public class Montecorlo
 		while(true)
 		{			
 			limit ++;
-			if(limit == 200)
+			if(limit == 1200)
 			{
 				result = new RoundData();
-				result.score = new int[4];
+				result.score = new int[2];
 				result.score[0] = 0;
 				result.score[1] = 0;
-				result.score[2] = 0;
-				result.score[3] = 0;
+				//result.score[2] = 0;
+				//result.score[3] = 0;
+				System.out.println("limited out!!!");
 				return result;
 			}
 			/*ここにターンの処理*/
 			Card card;
-		
+			
 			if(drawcount > 0) //Dカードがたまってる場合
 			{
 				str = tdis.getTopName();
 				card = list.makeCard(str);
 				if(thand[turn-1].isdrawCard() && thand[turn-1].dcanDiscard(card)) //Dカードを持ってるか
 				{
-					for(int i = 0;i < thand[turn-1].getNum();i++)
+					/*for(int i = 0;i < thand[turn-1].getNum();i++)
 					{
 						card = thand[turn -1].cardOut(i);
 						//System.out.println(card.getCardName());
-					}
+					}*/
 					int r = rand.nextInt(2);
 					if(r == 0) //Dカードを使う
 					{
@@ -388,6 +388,10 @@ public class Montecorlo
 				}
 				
 			}
+			
+			thand[turn-1].cardFix();
+			tdis.cardFix();
+			
 			if(thand[turn-1].getNum() == 0)
 			{
 				break;
@@ -445,7 +449,18 @@ public class Montecorlo
 	
 	private int turncount(int turn, int turnbase,int skipcount)
 	{
-		turn += turnbase;
+		if(skipcount == 0)
+		{
+			if(turn == 2)
+			{
+				turn = 1;
+			}
+			else 
+			{
+				turn = 2;
+			}
+		}
+		/*turn += turnbase;
 		turn += turnbase * skipcount;
 		if(turn == 0)
 		{
@@ -458,7 +473,7 @@ public class Montecorlo
 		else if(turn < 0)
 		{
 			turn = playerNum + turn;
-		}
+		}*/
 		
 		/*if(turn == 1)
 		{

--- a/UNOgame/src/UNOset/server/GameRun.java
+++ b/UNOgame/src/UNOset/server/GameRun.java
@@ -220,12 +220,12 @@ public class GameRun
 					{
 						int a = hand[0].getNum();
 						int b = hand[1].getNum();
-						int c = hand[2].getNum();
-						int d = hand[3].getNum();
+						//int c = hand[2].getNum();
+						//int d = hand[3].getNum();
 						server.sendMessage(turn,String.valueOf(a));
 						server.sendMessage(turn,String.valueOf(b));
-						server.sendMessage(turn,String.valueOf(c));
-						server.sendMessage(turn,String.valueOf(d));
+						//server.sendMessage(turn,String.valueOf(c));
+						//server.sendMessage(turn,String.valueOf(d));
 					}
 					else
 					{
@@ -318,7 +318,19 @@ public class GameRun
 	
 	private int turncount(int turn, int turnbase,int skipcount)
 	{
-		turn += turnbase;
+		if(skipcount == 0) 
+		{
+			if(turn == 1)
+			{
+				turn = 2;
+			}
+			else
+			{
+				turn = 1;
+			}
+		}
+			/*turn += turnbase;
+		
 		turn += turnbase * skipcount;
 		if(turn == 0)
 		{
@@ -331,7 +343,7 @@ public class GameRun
 		else if(turn < 0)
 		{
 			turn = playerNum + turn;
-		}
+		}*/
 		
 		/*if(turn == 1)
 		{

--- a/UNOgame/src/UNOset/server/TCPserver.java
+++ b/UNOgame/src/UNOset/server/TCPserver.java
@@ -18,9 +18,9 @@ public class TCPserver
 	}
 
 	//player‚ÆÚ‘±
-	boolean connect(int a, int b, int c, int d)
+	boolean connect(int a, int b)
 	{
-		if(0 == server.playerSet(a, b, c, d))
+		if(0 == server.playerSet(a, b))
 		{
 			return false;
 		}

--- a/UNOgame/src/UNOset/server/UNOserver.java
+++ b/UNOgame/src/UNOset/server/UNOserver.java
@@ -8,7 +8,7 @@ public class UNOserver
 
 	public static void main(String[] args)
 	{
-		int playerNum = 4;
+		int playerNum = 2;
 		
 		//ƒ|[ƒg‚Ìİ’è
 		//int a = Integer.parseInt(args[0]);
@@ -16,12 +16,12 @@ public class UNOserver
 		
 		int a = 555;
 		int b = 666;
-		int c = 777;
-		int d = 888;
+		//int c = 777;
+		//int d = 888;
 		
 		//TCPserver‚Æ‚ÌÚ‘±
 	    TCPserver server = new TCPserver(playerNum);
-	    if(!server.connect(a, b, c ,d))
+	    if(!server.connect(a, b))
 	    {
 	    	System.out.println("connect miss");
 	    	return;

--- a/UNOgame/src/UNOset/utils/DisCard.java
+++ b/UNOgame/src/UNOset/utils/DisCard.java
@@ -84,4 +84,20 @@ public class DisCard
    {
 	   return cards.size();   
    }
+   
+   public void cardFix()
+   {
+	   int n = this.cards.size();
+	   Card temp;
+	   for(int i = 0;i < n;i++)
+	   {
+		   temp = cards.get(i);
+		   if(temp == null)
+		   {
+			   cards.remove(i);
+			   i--;
+			   n--;
+		   }
+	   }
+   }
 }

--- a/UNOgame/src/UNOset/utils/Hand.java
+++ b/UNOgame/src/UNOset/utils/Hand.java
@@ -13,6 +13,7 @@ public class Hand
 	
 	public int getNum()
 	{
+		this.cardFix();
 		return hands.size();
 	}
 	
@@ -47,7 +48,7 @@ public class Hand
 	
 	public int serchCard(String name)
 	{
-		for(int i = 0;i < hands.size() ;i++)
+		for(int i = 0;i < this.getNum() ;i++)
 		{
 			if(name.equals((hands.get(i)).getCardName()))
 			{
@@ -60,7 +61,7 @@ public class Hand
 	
 	public void crean()
 	{
-		for(int i =0;i < hands.size();i++)
+		for(int i =0;i < this.getNum();i++)
 		{
 			Card card = hands.get(i);
 			if(card instanceof WildCard)
@@ -75,7 +76,7 @@ public class Hand
 		Card h;
 		boolean out = false;
 		String color = card.getCardColor();
-		for(int i = 0;i < hands.size();i++)
+		for(int i = 0;i < this.getNum();i++)
 		{
 			h = hands.get(i);
 			if(color.equals(h.getCardColor()))
@@ -120,7 +121,7 @@ public class Hand
 		Card h;
 		boolean out = false;
 		String color = card.getCardColor();
-		for(int i = 0;i < hands.size();i++)
+		for(int i = 0;i < this.getNum();i++)
 		{
 			h = hands.get(i);
 			if(h.isDrawcard())
@@ -142,12 +143,28 @@ public class Hand
 		return out;
 	}
 	
+	public void cardFix()
+	{
+		int n = this.hands.size();
+		Card temp;
+		for(int i = 0;i < n;i++)
+		{
+			temp = hands.get(i);
+			if(temp == null)
+			{
+				hands.remove(i);
+				i--;
+				n--;
+			}
+		}
+	}
+	
 	
 	public int result()
 	{
 		int result = 0;
 		Card card;
-		for(int i = 0;i < hands.size();i++)
+		for(int i = 0;i < this.getNum();i++)
 		{
 			card = hands.get(i);
 			if(card instanceof NumberCard)
@@ -168,7 +185,7 @@ public class Hand
 	
 	public boolean isdrawCard()
 	{
-		for(int i = 0;i < hands.size();i++)
+		for(int i = 0;i < this.getNum();i++)
 		{
 			Card card = hands.get(i);
 			if(card.isDrawcard())
@@ -182,7 +199,7 @@ public class Hand
 	public int colors(String co)
 	{
 		int num = 0;
-		for(int i = 0;i < hands.size();i++)
+		for(int i = 0;i < this.getNum();i++)
 		{
 			String temp = (hands.get(i)).getCardColor();
 			if(temp.equals(co))


### PR DESCRIPTION
テスト用に2人制にした　nullは排除するように手札墓地を変更
シュミレーション中に600手辺りを超えるとおかしくなってCPUとメモリをめっちゃ喰う
手数に制限かけてる　デッキ切れの処理が怪しいかも